### PR TITLE
fix: set MIT licence in Metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 keywords = ["FastAPI", "SQLAlchemy", "AsyncIO"]
-license = { text = "MIT License" }
+license-files = ["./LICENSE"]
 dependencies = ["fastapi>=0.115.6", "sqlalchemy[asyncio]>=2.0.37", "structlog>=24.4.0"]
 
 [project.urls]


### PR DESCRIPTION
# Problem

* Failing https://github.com/hadrien/FastSQLA/actions/runs/18232155820/job/51917853949
* > ERROR    InvalidDistribution: Invalid distribution metadata: unrecognized or    
         malformed field 'license-file'   

# Solution

* Set licence & licence-file
