### PR TITLE
fix: pin pygments to upstream filename=None fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ docs = [
     "mkdocs-llmstxt>=0.5.0",
     "mkdocs-material>=9.7.1",
     "mkdocstrings[python]>=1.0.0",
+    "pygments @ git+https://github.com/pygments/pygments.git@b6f6dab78e13652741d5e5811b4256b4dcb5fcd8",
 ]
 sqlmodel = ["sqlmodel>=0.0.22"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 
 [[package]]
 name = "fastsqla"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -421,6 +421,7 @@ docs = [
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pygments" },
 ]
 sqlmodel = [
     { name = "sqlmodel" },
@@ -451,6 +452,7 @@ requires-dist = [
     { name = "mkdocs-llmstxt", marker = "extra == 'docs'", specifier = ">=0.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7.1" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=1.0.0" },
+    { name = "pygments", marker = "extra == 'docs'", git = "https://github.com/pygments/pygments.git?rev=b6f6dab78e13652741d5e5811b4256b4dcb5fcd8" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.37" },
     { name = "sqlmodel", marker = "extra == 'sqlmodel'", specifier = ">=0.0.22" },
     { name = "structlog", specifier = ">=24.4.0" },
@@ -1136,11 +1138,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.20.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
+source = { git = "https://github.com/pygments/pygments.git?rev=b6f6dab78e13652741d5e5811b4256b4dcb5fcd8#b6f6dab78e13652741d5e5811b4256b4dcb5fcd8" }
 
 [[package]]
 name = "pymdown-extensions"


### PR DESCRIPTION
# Problem
- `uv run mkdocs build` fails: `AttributeError: 'NoneType' object has no attribute 'replace'`.
- Pygments 2.20.0 wraps `filename` with `html.escape` ([0f97e7c](https://github.com/pygments/pygments/commit/0f97e7c37d)).
- `pymdown-extensions` passes `filename=None` for mkdocstrings source blocks without a title.
- Upstream fix [PR #3086](https://github.com/pygments/pygments/pull/3086) is merged but unreleased.

# Solution
- Pin pygments to commit `b6f6dab` via git URL in the `docs` extra.
- Drop the pin once Pygments 2.20.1 ships.