### PR TITLE
docs: build doc on tags instead of main

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -2,8 +2,9 @@ name: Build & Publish Doc
 
 on:
   push:
+    tags:
+      - '*'
     branches:
-      - main
       - docs/**
 
 jobs:


### PR DESCRIPTION
## Summary
- Trigger doc build & publish workflow on tag pushes instead of pushes to `main`
- Keep `docs/**` branch trigger for previewing doc changes

## Test plan
- [ ] Push a tag and verify the doc workflow runs and deploys to GitHub Pages