### PR TITLE
ci: allow manual trigger of doc build workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,7 @@ on:
       - '*'
     branches:
       - docs/**
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to the doc build & publish workflow so it can be run on demand from the GitHub Actions UI

## Test plan
- [x] After merge, trigger the workflow manually from the Actions tab and verify it builds and deploys docs