### PR TITLE
ci: auto-merge dependabot pull requests

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.repository == 'hadrien/FastSQLA'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Approve pull request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
# Problem

- Dependabot pull requests require manual approval and merging.
- Auto-merge lacked required CI gates on main.

# Solution

- Require all three test matrices and Ruff on main.
- Enable repository auto-merge with squash-only merging.
- Approve Dependabot pull requests with the built-in token.
- Schedule squash merges after required checks pass.

fs-pkw