### PR TITLE
docs: publish Context7 claim file

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,6 +27,8 @@ jobs:
       run: uv sync --extra docs
     - name: 📙 mkdocs build
       run: uv run mkdocs build
+    - name: 🔑 publish Context7 claim
+      run: cp context7.json site/context7.json
     - name: 📦 Upload artifacts
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,12 +28,9 @@ jobs:
     - name: 📙 mkdocs build
       run: uv run mkdocs build
     - name: 🔑 publish Context7 claim
-      run: |
-        mkdir -p site/llms site/llms-full
+      run: >-
         jq '{url: "https://context7.com/llmstxt/hadrien_github_io_fastsqla_llms_txt",
-        public_key}' context7.json > site/llms/context7.json
-        jq '{url: "https://context7.com/llmstxt/hadrien_github_io_fastsqla_llms-full_txt",
-        public_key}' context7.json > site/llms-full/context7.json
+        public_key}' context7.json > site/context7.json
     - name: 📦 Upload artifacts
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,9 @@ jobs:
     - name: 📙 mkdocs build
       run: uv run mkdocs build
     - name: 🔑 publish Context7 claim
-      run: cp context7.json site/context7.json
+      run: >-
+        jq '{url: "https://context7.com/llmstxt/hadrien_github_io_fastsqla_llms-full_txt",
+        public_key}' context7.json > site/context7.json
     - name: 📦 Upload artifacts
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,9 +28,10 @@ jobs:
     - name: 📙 mkdocs build
       run: uv run mkdocs build
     - name: 🔑 publish Context7 claim
-      run: >-
+      run: |
+        mkdir -p site/llms-full
         jq '{url: "https://context7.com/llmstxt/hadrien_github_io_fastsqla_llms-full_txt",
-        public_key}' context7.json > site/context7.json
+        public_key}' context7.json > site/llms-full/context7.json
     - name: 📦 Upload artifacts
       uses: actions/upload-pages-artifact@v3
       with:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,7 +29,9 @@ jobs:
       run: uv run mkdocs build
     - name: 🔑 publish Context7 claim
       run: |
-        mkdir -p site/llms-full
+        mkdir -p site/llms site/llms-full
+        jq '{url: "https://context7.com/llmstxt/hadrien_github_io_fastsqla_llms_txt",
+        public_key}' context7.json > site/llms/context7.json
         jq '{url: "https://context7.com/llmstxt/hadrien_github_io_fastsqla_llms-full_txt",
         public_key}' context7.json > site/llms-full/context7.json
     - name: 📦 Upload artifacts


### PR DESCRIPTION
# Problem

- Context7 cannot claim the `llms.txt` library because its root claim file is missing.

# Solution

- Generate the two-field claim at `context7.json` in the Pages artifact.
- Target the exact `llms.txt` Context7 library URL.
- Derive the public key from the canonical repository configuration.
- Remove the nested `llms` and `llms-full` claims.

fs-1rc.6
