### PR TITLE
chore: configure dependency commit semantics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    commit-message:
+      prefix: build
+      prefix-development: chore
+      include: scope
 
   - package-ecosystem: github-actions
     directory: /
@@ -19,3 +23,6 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    commit-message:
+      prefix: ci
+      include: scope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,9 @@ env = "GH_TOKEN"
 version_toml = ["pyproject.toml:project.version"]
 allow_zero_version = true
 
+[tool.semantic_release.commit_parser_options]
+patch_tags = ["fix", "perf", "build"]
+
 [tool.semantic_release.changelog]
 mode = "init"
 


### PR DESCRIPTION
# Problem

- Dependency maintenance uses `fix`, conflating updates with application bug fixes.
- Development and GitHub Actions updates unnecessarily trigger package releases.

# Solution

- Use `build(deps)` for uv production updates.
- Use `chore(deps-dev)` for uv development updates.
- Use `ci(deps)` for GitHub Actions updates.
- Map `build` commits to patch releases in Python Semantic Release.

fs-7xu