### PR TITLE
ci: fix Dependabot Actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
     commit-message:
       prefix: ci
       include: scope


### PR DESCRIPTION
# Problem

- Dependabot rejects SemVer-specific cooldown fields for the GitHub Actions ecosystem.
- Invalid configuration blocks dependency update processing.

# Solution

- Keep the supported five-day default cooldown for GitHub Actions.
- Preserve uv SemVer cooldowns and dependency commit-message settings.

fs-5cd