### PR TITLE
fix(ci): dispatch release checks explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   Tests:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,14 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 jobs:
 
   Release-And-Publish:
     runs-on: ubuntu-latest
-    concurrency: release-${{ github.ref_type }}
+    concurrency: release
     permissions:
-      actions: read
+      actions: write
       contents: write
       id-token: write
     steps:
@@ -21,19 +19,10 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
-        persist-credentials: false
     - name: 🔧 setup uv
       uses: ./.github/uv
     - name: 📜 semantic release version & publish on PyPI
       run: |
-        if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-          uv run semantic-release changelog --post-to-release-tag "$GITHUB_REF_NAME"
-          echo "🙆🏽 Publishing on PyPI"
-          uv build
-          uv run twine upload dist/*
-          exit 0
-        fi
-
         next_version=$(uv run semantic-release version --print)
         last_released_version=$(uv run semantic-release version --print-last-released)
         if [[ "$next_version" == "$last_released_version" ]]; then
@@ -43,8 +32,8 @@ jobs:
           uv run semantic-release version --no-push --no-vcs-release
           release_sha=$(git rev-parse HEAD)
           release_branch="release/${release_tag}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          release_remote="https://${GITHUB_ACTOR}:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push "$release_remote" "HEAD:refs/heads/${release_branch}"
+          git push origin "HEAD:refs/heads/${release_branch}"
+          gh workflow run ci.yml --ref "$release_branch"
 
           ci_run_id=""
           for _ in {1..120}; do
@@ -52,6 +41,7 @@ jobs:
               --workflow ci.yml \
               --branch "$release_branch" \
               --commit "$release_sha" \
+              --event workflow_dispatch \
               --limit 1 \
               --json databaseId \
               --jq '.[0].databaseId')
@@ -66,13 +56,17 @@ jobs:
           fi
 
           gh run watch "$ci_run_id" --exit-status
-          git push --atomic "$release_remote" \
+          git push --atomic origin \
             "HEAD:refs/heads/main" \
             "refs/tags/${release_tag}:refs/tags/${release_tag}"
-          git push "$release_remote" --delete "$release_branch"
+          git push origin --delete "$release_branch"
+          gh workflow run doc.yml --ref "$release_tag"
+          uv run semantic-release changelog --post-to-release-tag "$release_tag"
+          echo "🙆🏽 Publishing on PyPI"
+          uv build
+          uv run twine upload dist/*
         fi
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
         TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
# Problem\n\n- The stored release PAT is invalid.\n- Built-in token pushes do not automatically start required CI workflows.\n\n# Solution\n\n- Add manual dispatch support to the existing CI workflow.\n- Dispatch CI on the temporary release ref with the built-in token.\n- Wait for the exact release SHA before atomic promotion.\n- Publish release notes and PyPI from the originating workflow.\n- Dispatch documentation for the promoted tag.\n- Remove the PAT dependency without weakening main protection.\n\nfs-3z4