### PR TITLE
fix(ci): set release tagger identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,8 @@ jobs:
           merge_sha=$(jq -r .sha <<< "$merge_response")
           git fetch origin main
           git merge-base --is-ancestor "$merge_sha" origin/main
-          git tag --force --annotate "$release_tag" "$merge_sha" --message "$release_tag"
+          git -c user.name=semantic-release -c user.email=semantic-release \
+            tag --force --annotate "$release_tag" "$merge_sha" --message "$release_tag"
           git push origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
           if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null; then
             git push origin --delete "$release_branch"


### PR DESCRIPTION
# Problem

- Annotated release tags fail after protected release pull requests merge.
- Git has no tagger identity in the Actions runner.

# Solution

- Apply the established semantic-release identity to tag creation.
- Scope the identity to one Git invocation.

fs-3z4